### PR TITLE
Force import existing proxy and implementation addresses in upgrade script

### DIFF
--- a/.github/workflows/testnet-deployment-upgrade.yml
+++ b/.github/workflows/testnet-deployment-upgrade.yml
@@ -4,6 +4,8 @@ on:
     push:
       branches:
         - main
+      paths:
+        - 'src/**'
     workflow_dispatch:
 
 env:

--- a/scripts/upgradeProxyImplementation.ts
+++ b/scripts/upgradeProxyImplementation.ts
@@ -6,6 +6,10 @@ async function main() {
 
   //@ts-ignore
   const didRegistryContract = await ethers.getContractFactory("DIDRegistry", relaySigner);
+
+  // Import the proxy and implementation contract so they are resolved
+  await defender.forceImport(process.env.DID_REGISTRY_PROXY_ADDRESS!, didRegistryContract, {kind: 'uups'});
+
   const proposalResponse = await defender.proposeUpgrade(process.env.DID_REGISTRY_PROXY_ADDRESS!, didRegistryContract, {
     multisig: process.env.GNOSIS_ADDRESS!,
     kind: 'uups',


### PR DESCRIPTION
The error that I see for for each job is indicating it can't resolve the previously deployed implementation contract on the proxy. This PR adds a forceImport in order to resolve both the proxy contract and the implementation contract.